### PR TITLE
Only prefer `~/.local/state/nix/profile` if `use-xdg-base-directories` is set

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -32,7 +32,7 @@ impl App {
         let nix = config.nix()?;
         let nix_file = config.nix_file()?;
         // TODO: Should we create this profile if it doesn't exist?
-        let nix_profile = config.nix_profile()?;
+        let nix_profile = config.nix_profile(&nix)?;
         let hostname = config.hostname()?;
         ::tracing::debug!(%nix_file, ?nix_profile, %hostname, "Resolved configuration");
         Ok(Self {

--- a/src/config.rs
+++ b/src/config.rs
@@ -223,7 +223,7 @@ impl Config {
         }
     }
 
-    pub fn nix_profile(&self) -> miette::Result<Option<Utf8PathBuf>> {
+    pub fn nix_profile(&self, nix: &Nix) -> miette::Result<Option<Utf8PathBuf>> {
         if let Some(profile) = self.switch_args.profile.profile.as_deref() {
             return Ok(Some(profile.to_path_buf()));
         }
@@ -232,7 +232,7 @@ impl Config {
             return Ok(Some(self.project_paths.expand_tilde(profile)?));
         }
 
-        self.project_paths.nix_profile()
+        self.project_paths.nix_profile(nix)
     }
 
     pub fn nix(&self) -> miette::Result<Nix> {


### PR DESCRIPTION
We were incorrectly using `~/.local/state/nix/profiles/profile` as the profile when that's not what Nix does.