### PR TITLE
`src/nix/build.rs`: remove

### DIFF
--- a/src/nix/build.rs
+++ b/src/nix/build.rs
@@ -1,3 +1,0 @@
-use super::Nix;
-
-impl Nix {}


### PR DESCRIPTION
This wasn't being used and didn't contain anything anyways.