### PR TITLE
lib: don't `inherit (final) callPackage`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -4,8 +4,6 @@
 }:
 lib.recurseIntoAttrs (
   lib.makeScope newScope (final: {
-    inherit (final) callPackage newScope;
-
     makePins = final.callPackage ./makePins.nix { };
 
     makePackages = final.callPackage ./makePackages.nix { };


### PR DESCRIPTION
I'm not sure this was ever needed, but it causes problems with the lastest Nixpkgs.

See: https://github.com/NixOS/nixpkgs/pull/500752#issuecomment-4112198489