### PR TITLE
Fix #67: don't say "Updated profile" during npingler build

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -312,8 +312,13 @@ impl App {
         };
 
         let diff = diff_trees::Diff::new(old.as_std_path(), new.as_std_path()).into_diagnostic()?;
+        // We have to display the diff to see if it's actually empty. See https://github.com/9999years/npingler/issues/68
+        let displayed_diff = format!(
+            "{}",
+            diff.display(diff_trees::DisplayDiffOpts::new().color(true))
+        );
 
-        if diff.is_empty() {
+        if displayed_diff.is_empty() {
             // Sometimes, the profile path changes, but no installed paths actually
             // change their contents. Instead of showing a blank diff, we list the old and new
             // profiles.
@@ -323,10 +328,7 @@ impl App {
                 format!("+ {new}").green(),
             );
         } else {
-            tracing::info!(
-                "Updated Nix profile:\n{}",
-                diff.display(diff_trees::DisplayDiffOpts::new().color(true))
-            );
+            tracing::info!("Updated Nix profile:\n{}", displayed_diff);
         }
 
         Ok(())

--- a/src/app.rs
+++ b/src/app.rs
@@ -234,7 +234,7 @@ impl App {
     }
 
     #[instrument(level = "debug", skip(self))]
-    pub fn build_packages(&self) -> miette::Result<Utf8PathBuf> {
+    pub fn build_packages(&self) -> miette::Result<(Option<Utf8PathBuf>, Utf8PathBuf)> {
         tracing::info!("Building profile packages");
 
         let old_profile = self
@@ -294,20 +294,19 @@ impl App {
             tracing::info!("No changes, profile already up to date");
         } else if let Err(err) = self.diff_trees(old_profile.as_deref(), new_profile.as_path()) {
             let old_profile = old_profile
+                .clone()
                 .map(|path| path.as_str().to_owned())
                 .unwrap_or_default();
             tracing::debug!("Failed to diff profiles {old_profile} -> {new_profile}:\n{err}");
         }
 
-        Ok(new_profile)
+        Ok((old_profile, new_profile))
     }
 
     fn diff_trees(&self, old: Option<&Utf8Path>, new: &Utf8Path) -> miette::Result<()> {
+        tracing::info!("Built Nix profile: {new}");
         let old = match old {
-            None => {
-                tracing::info!("Updated Nix profile to {new}");
-                return Ok(());
-            }
+            None => return Ok(()),
             Some(old) => old,
         };
 
@@ -320,15 +319,10 @@ impl App {
 
         if displayed_diff.is_empty() {
             // Sometimes, the profile path changes, but no installed paths actually
-            // change their contents. Instead of showing a blank diff, we list the old and new
-            // profiles.
-            tracing::info!(
-                "Updated Nix profile:\n{}\n{}",
-                format!("- {old}").red(),
-                format!("+ {new}").green(),
-            );
+            // change their contents.
+            tracing::info!("No changes from current profile");
         } else {
-            tracing::info!("Updated Nix profile:\n{}", displayed_diff);
+            tracing::info!("Changes from current profile:\n{}", displayed_diff);
         }
 
         Ok(())
@@ -336,9 +330,17 @@ impl App {
 
     #[instrument(level = "debug", skip(self))]
     pub fn ensure_packages(&self) -> miette::Result<()> {
-        let new_profile = self.build_packages()?;
+        let (old_profile, new_profile) = self.build_packages()?;
 
-        tracing::info!("Setting profile to {new_profile}");
+        match old_profile {
+            Some(old) if old == new_profile => return Ok(()),
+            Some(old) => tracing::info!(
+                "Updating profile:\n{}\n{}",
+                format!("- {old}").red(),
+                format!("+ {new_profile}").green()
+            ),
+            None => tracing::info!("Updating profile:\n{}", format!("+ {new_profile}").green()),
+        }
 
         if let Some(profile_dir) = self.nix_profile.parent()
             && fs_err::symlink_metadata(profile_dir).is_err()


### PR DESCRIPTION
Stacked on top of #69. Fixes #67 

One other thing I've changed here is to have npingler print the new profile store path during `build` (if it differs from the current profile). I've wanted this a couple of times to be able to inspect the results before switching.

There are 6 situations you can be in here: [build, switch] x [profile store path unchanged, changed but no diff, changed with diff], so I've tested the output in all 6 and reproduced it below:

## build
### Profile store path unchanged
```
> npingler build
• Building profile packages
• No changes, profile already up to date
```

### Profile store path changed, no diff
```
> npingler build
• Building profile packages
[build logs]
• Built Nix profile: /nix/store/39ih1hxj128ihl68zfcc9vbwr01fsc06-npingler-packages
• No changes from current profile
```

### Profile store path changed, diff
```
> npingler build
• Building profile packages
[build logs]
• Built Nix profile: /nix/store/iq0x4kjvk9bc8k4cc92gb329n5hk9kic-npingler-packages

• Changes from current profile:
  - bin/.gh-wrapped
  ~ bin/.npins-wrapped
  ~ bin/.vimdot-wrapped
[…]
```

## switch
### Profile store path unchanged
```
> npingler switch
• Building profile packages
• No changes, profile already up to date
```

### Profile store path changed, no diff
```
> npingler switch
• Building profile packages
[build logs]
• Built Nix profile: /nix/store/96aa4xvlr1n1j3pnsa94975zc8405qac-npingler-packages
• No changes from current profile

• Updating profile:
  - /nix/store/39ih1hxj128ihl68zfcc9vbwr01fsc06-npingler-packages
  + /nix/store/96aa4xvlr1n1j3pnsa94975zc8405qac-npingler-packages
```

### Profile store path changed, diff
```
• Building profile packages
[build logs]
• Built Nix profile: /nix/store/q53vkxfm2152hmljis1hmn3nx7yy161f-npingler-packages

• Changes from current profile:
  ~ share/nix-direnv/direnvrc


• Updating profile:
  - /nix/store/96aa4xvlr1n1j3pnsa94975zc8405qac-npingler-packages
  + /nix/store/q53vkxfm2152hmljis1hmn3nx7yy161f-npingler-packages
```