### PR TITLE
Handle "flakes: null" in flake registries

### DIFF
--- a/src/nix/registry.rs
+++ b/src/nix/registry.rs
@@ -50,12 +50,14 @@ struct UnknownRegistry {
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct RegistryV2 {
-    flakes: Vec<RegistryEntryV2>,
+    // This is an Option<Vec<_>> because removing the last entry in a flake registry can leave you
+    // with "flakes: null"
+    flakes: Option<Vec<RegistryEntryV2>>,
 }
 
 impl RegistryV2 {
     pub fn id_to_path<'s>(&'s self, id: &str) -> Option<&'s Utf8Path> {
-        for flake in &self.flakes {
+        for flake in self.flakes.iter().flatten() {
             if let ReferenceV2::Indirect { id: current_id } = &flake.from
                 && current_id == id
             {


### PR DESCRIPTION
To reproduce:

- run `sudo nix registry remove --registry /etc/nix/registry.json [name]` until there's nothing left in there (at which point that file's contents should be: `{"flakes": null,"version": 2}`
- run `npingler switch` with config `registry.pin_root = true`

Before:
```
» npingler switch
• Building profile packages
• No changes, profile already up to date
• Setting profile to /nix/store/nv9gyfbfk087lw85b1slc8af1bhblqg1-npingler-packages

⚠   × Failed to deserialize Flake registry
    ╰─▶ invalid type: null, expected a sequence


• Pinning `root` Nix Flake registry entries
• Pinning registry entry nixpkgs to /nix/store/837gqq5wrk8s96zm7wjf0ipr74jzpwnz-source
warning: $HOME ('/Users/harry') is not owned by you, falling back to the one defined in the 'passwd' file ('/var/root')
• Pinning channels
• Channels are already set to /nix/store/ygllamzrxvfzyjm6wyirab8xz9r6hpx8-user-environment
```

After:
```
• Building profile packages
• No changes, profile already up to date
• Setting profile to /nix/store/nv9gyfbfk087lw85b1slc8af1bhblqg1-npingler-packages
• Pinning `root` Nix Flake registry entries
• Pinning registry entry nixpkgs to /nix/store/837gqq5wrk8s96zm7wjf0ipr74jzpwnz-source
warning: $HOME ('/Users/harry') is not owned by you, falling back to the one defined in the 'passwd' file ('/var/root')
• Pinning channels
• Channels are already set to /nix/store/ygllamzrxvfzyjm6wyirab8xz9r6hpx8-user-environment
```

This doesn't actually change npingler's behaviour at all, it's just nice to avoid the error text