### PR TITLE
Handle flake registry file not existing

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -474,7 +474,7 @@ impl App {
         let pins: NixPins = self.eval_npingler_attr("pins.pins", None)?;
 
         let registry = match self.nix.parse_registry(Nix::system_registry_path()) {
-            Ok(registry) => Some(registry),
+            Ok(registry) => registry,
             Err(error) => {
                 tracing::warn!("{error:?}");
                 None

--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::io::ErrorKind;
 use std::os::unix::process::CommandExt as _;
 use std::process::Command;
 use std::process::Output;
@@ -136,14 +137,21 @@ impl Nix {
         Utf8Path::new("/etc/nix/registry.json")
     }
 
-    pub fn parse_registry(&self, path: &Utf8Path) -> miette::Result<Registry> {
-        let contents = fs_err::read_to_string(path)
-            .into_diagnostic()
-            .wrap_err("Failed to read Flake registry")?;
+    pub fn parse_registry(&self, path: &Utf8Path) -> miette::Result<Option<Registry>> {
+        match fs_err::read_to_string(path) {
+            Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
+            contents => {
+                let contents = contents
+                    .into_diagnostic()
+                    .wrap_err("Failed to read Flake registry")?;
 
-        serde_json::from_str(&contents)
-            .into_diagnostic()
-            .wrap_err("Failed to deserialize Flake registry")
+                Ok(Some(
+                    serde_json::from_str(&contents)
+                        .into_diagnostic()
+                        .wrap_err("Failed to deserialize Flake registry")?,
+                ))
+            }
+        }
     }
 
     // `nix derivation show` wrapper.


### PR DESCRIPTION
Fixes #72. To reproduce, delete `/etc/nix/registry.json` before running `npingler switch` with `registry.pin_root = true`.

Before:
```
• Building profile packages
• No changes, profile already up to date
• Setting profile to /nix/store/nv9gyfbfk087lw85b1slc8af1bhblqg1-npingler-packages

⚠   × Failed to read Flake registry
    ╰─▶ failed to open file `/etc/nix/registry.json`: No such file or directory (os error 2)


• Pinning `root` Nix Flake registry entries
• Pinning registry entry nixpkgs to /nix/store/837gqq5wrk8s96zm7wjf0ipr74jzpwnz-source
warning: $HOME ('/Users/harry') is not owned by you, falling back to the one defined in the 'passwd' file ('/var/root')
• Pinning channels
• Channels are already set to /nix/store/ygllamzrxvfzyjm6wyirab8xz9r6hpx8-user-environment
```

After:
```
• Building profile packages
• No changes, profile already up to date
• Setting profile to /nix/store/nv9gyfbfk087lw85b1slc8af1bhblqg1-npingler-packages
• Pinning `root` Nix Flake registry entries
• Pinning registry entry nixpkgs to /nix/store/837gqq5wrk8s96zm7wjf0ipr74jzpwnz-source
warning: $HOME ('/Users/harry') is not owned by you, falling back to the one defined in the 'passwd' file ('/var/root')
• Pinning channels
• Channels are already set to /nix/store/ygllamzrxvfzyjm6wyirab8xz9r6hpx8-user-environment
```

This PR doesn't affect the outcome of running `npingler switch`, it just means we avoid printing error text for a non-error case